### PR TITLE
feat: add allowlisted baggage span processor support

### DIFF
--- a/src/baggage_span_processor.rs
+++ b/src/baggage_span_processor.rs
@@ -1,0 +1,125 @@
+use opentelemetry::baggage::BaggageExt;
+use opentelemetry::trace::Span as _;
+use opentelemetry::{Context, Key, KeyValue, Value};
+use opentelemetry_sdk::trace::{Span, SpanProcessor};
+use std::collections::HashSet;
+
+/// A [`SpanProcessor`] that copies allowlisted [baggage] entries into span
+/// attributes on start.
+///
+/// OTel baggage is propagated across service boundaries but is **not**
+/// automatically attached to spans. This processor bridges that gap: it reads
+/// baggage from the parent [`Context`] during `on_start` and sets matching
+/// entries as span attributes.
+///
+/// Only keys present in the configured allowlist are copied — this prevents
+/// accidentally leaking sensitive baggage into traces.
+///
+/// [baggage]: https://opentelemetry.io/docs/concepts/signals/baggage/
+#[derive(Debug)]
+pub struct BaggageSpanProcessor {
+    allowed_keys: HashSet<Key>,
+}
+
+impl BaggageSpanProcessor {
+    /// Create a new processor that will copy the given baggage keys into span
+    /// attributes.
+    ///
+    /// ```rust,ignore
+    /// use opentelemetry::Key;
+    ///
+    /// let processor = BaggageSpanProcessor::new([
+    ///     Key::from_static_str("user.id"),
+    ///     Key::from_static_str("tenant.id"),
+    /// ]);
+    /// ```
+    pub fn new(allowed_keys: impl IntoIterator<Item = Key>) -> Self {
+        Self {
+            allowed_keys: allowed_keys.into_iter().collect(),
+        }
+    }
+}
+
+impl SpanProcessor for BaggageSpanProcessor {
+    fn on_start(&self, span: &mut Span, cx: &Context) {
+        let baggage = cx.baggage();
+        for (key, (value, _metadata)) in baggage.iter() {
+            if self.allowed_keys.contains(key) {
+                span.set_attribute(KeyValue::new(key.clone(), Value::String(value.clone())));
+            }
+        }
+    }
+
+    fn on_end(&self, _span: opentelemetry_sdk::trace::SpanData) {}
+
+    fn force_flush(&self) -> opentelemetry_sdk::error::OTelSdkResult {
+        Ok(())
+    }
+
+    fn shutdown_with_timeout(
+        &self,
+        _timeout: std::time::Duration,
+    ) -> opentelemetry_sdk::error::OTelSdkResult {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry::trace::{Tracer, TracerProvider};
+
+    fn build_span() -> Span {
+        let provider = opentelemetry_sdk::trace::SdkTracerProvider::builder().build();
+        let tracer = provider.tracer("test");
+        tracer.build(opentelemetry::trace::SpanBuilder::from_name("test"))
+    }
+
+    #[test]
+    fn copies_allowlisted_keys_only() {
+        let processor = BaggageSpanProcessor::new([
+            Key::from_static_str("user.id"),
+            Key::from_static_str("tenant.id"),
+        ]);
+
+        let cx = Context::new().with_baggage([
+            KeyValue::new("user.id", "42"),
+            KeyValue::new("tenant.id", "acme"),
+            KeyValue::new("secret", "should-not-appear"),
+        ]);
+
+        let mut span = build_span();
+        processor.on_start(&mut span, &cx);
+
+        let data = span.exported_data().expect("span should have data");
+        let keys: Vec<&str> = data.attributes.iter().map(|kv| kv.key.as_str()).collect();
+
+        assert!(keys.contains(&"user.id"));
+        assert!(keys.contains(&"tenant.id"));
+        assert!(!keys.contains(&"secret"));
+    }
+
+    #[test]
+    fn no_op_when_baggage_is_empty() {
+        let processor = BaggageSpanProcessor::new([Key::from_static_str("user.id")]);
+        let cx = Context::new();
+
+        let mut span = build_span();
+        processor.on_start(&mut span, &cx);
+
+        let data = span.exported_data().expect("span should have data");
+        assert!(data.attributes.is_empty());
+    }
+
+    #[test]
+    fn no_op_when_allowlist_is_empty() {
+        let processor = BaggageSpanProcessor::new([]);
+        let cx = Context::new().with_baggage([KeyValue::new("user.id", "42")]);
+
+        let mut span = build_span();
+        processor.on_start(&mut span, &cx);
+
+        let data = span.exported_data().expect("span should have data");
+        assert!(data.attributes.is_empty());
+    }
+}

--- a/src/init.rs
+++ b/src/init.rs
@@ -34,11 +34,37 @@ pub fn init(
     sentry_dsn: &str,
     rust_log: &str,
 ) -> anyhow::Result<Handle> {
-    use opentelemetry_sdk::propagation::TraceContextPropagator;
+    init_with_baggage(
+        name,
+        version,
+        instance,
+        otel_endpoint,
+        sentry_dsn,
+        rust_log,
+        [],
+    )
+}
+
+pub fn init_with_baggage(
+    name: &'static str,
+    version: &'static str,
+    instance: &str,
+    otel_endpoint: &str,
+    sentry_dsn: &str,
+    rust_log: &str,
+    baggage_allowlist: impl IntoIterator<Item = opentelemetry::Key>,
+) -> anyhow::Result<Handle> {
+    let baggage_allowlist = baggage_allowlist.into_iter().collect::<Vec<_>>();
 
     let (sentry, sentry_logger) = sentry(sentry_dsn, version);
     let logger_provider = logger(otel_endpoint, name, version, instance)?;
-    let tracer_provider = tracer(otel_endpoint, name, version, instance)?;
+    let tracer_provider = tracer(
+        otel_endpoint,
+        name,
+        version,
+        instance,
+        baggage_allowlist.clone(),
+    )?;
     let meter_provider = meter(otel_endpoint, name, version, instance)?;
 
     let env_logger = env_logger::Builder::new()
@@ -51,7 +77,9 @@ pub fn init(
     log::set_max_level(env_logger.filter());
     log::set_boxed_logger(Box::new(Logger(env_logger, sentry_logger, otel_logger)))?;
 
-    opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
+    opentelemetry::global::set_text_map_propagator(text_map_propagator(
+        !baggage_allowlist.is_empty(),
+    ));
     opentelemetry::global::set_tracer_provider(tracer_provider.clone());
     opentelemetry::global::set_meter_provider(meter_provider.clone());
 
@@ -61,6 +89,20 @@ pub fn init(
         logger_provider,
         meter_provider,
     })
+}
+
+fn text_map_propagator(
+    include_baggage: bool,
+) -> opentelemetry::propagation::TextMapCompositePropagator {
+    use opentelemetry_sdk::propagation::{BaggagePropagator, TraceContextPropagator};
+
+    let mut propagators: Vec<Box<dyn opentelemetry::propagation::TextMapPropagator + Send + Sync>> =
+        vec![Box::new(TraceContextPropagator::new())];
+    if include_baggage {
+        propagators.insert(0, Box::new(BaggagePropagator::new()));
+    }
+
+    opentelemetry::propagation::TextMapCompositePropagator::new(propagators)
 }
 
 fn logger(
@@ -86,7 +128,7 @@ fn logger(
                 .with_attributes([
                     opentelemetry::KeyValue::new(SERVICE_NAME, name),
                     opentelemetry::KeyValue::new(SERVICE_VERSION, version),
-                    opentelemetry::KeyValue::new(SERVICE_INSTANCE_ID, instance.to_string()),
+                    opentelemetry::KeyValue::new(SERVICE_INSTANCE_ID, instance.to_owned()),
                 ])
                 .build(),
         )
@@ -122,7 +164,7 @@ fn meter(
                 .with_attributes([
                     opentelemetry::KeyValue::new(SERVICE_NAMESPACE, name),
                     opentelemetry::KeyValue::new(SERVICE_NAME, version),
-                    opentelemetry::KeyValue::new(SERVICE_INSTANCE_ID, instance.to_string()),
+                    opentelemetry::KeyValue::new(SERVICE_INSTANCE_ID, instance.to_owned()),
                 ])
                 .build(),
         )
@@ -134,6 +176,7 @@ fn tracer(
     name: &'static str,
     version: &'static str,
     instance: &str,
+    baggage_allowlist: impl IntoIterator<Item = opentelemetry::Key>,
 ) -> anyhow::Result<opentelemetry_sdk::trace::SdkTracerProvider> {
     use opentelemetry_otlp::{WithExportConfig, WithTonicConfig};
     use opentelemetry_semantic_conventions::resource::{
@@ -146,18 +189,25 @@ fn tracer(
         .with_compression(opentelemetry_otlp::Compression::Gzip)
         .build()?;
 
-    Ok(opentelemetry_sdk::trace::SdkTracerProvider::builder()
+    let mut builder = opentelemetry_sdk::trace::SdkTracerProvider::builder()
         .with_batch_exporter(exporter)
         .with_resource(
             opentelemetry_sdk::Resource::builder()
                 .with_attributes([
                     opentelemetry::KeyValue::new(SERVICE_NAME, name),
                     opentelemetry::KeyValue::new(SERVICE_VERSION, version),
-                    opentelemetry::KeyValue::new(SERVICE_INSTANCE_ID, instance.to_string()),
+                    opentelemetry::KeyValue::new(SERVICE_INSTANCE_ID, instance.to_owned()),
                 ])
                 .build(),
-        )
-        .build())
+        );
+
+    let allowed: std::collections::HashSet<opentelemetry::Key> =
+        baggage_allowlist.into_iter().collect();
+    if !allowed.is_empty() {
+        builder = builder.with_span_processor(crate::BaggageSpanProcessor::new(allowed));
+    }
+
+    Ok(builder.build())
 }
 
 fn sentry(
@@ -168,7 +218,7 @@ fn sentry(
     sentry_log::SentryLogger<sentry_log::NoopLogger>,
 ) {
     let sentry = sentry::init((
-        dsn.to_string(),
+        dsn.to_owned(),
         sentry::ClientOptions {
             release: Some(std::borrow::Cow::Owned(String::from(version))),
             ..Default::default()
@@ -234,5 +284,29 @@ impl sentry::Integration for SentryOtel {
         );
 
         Some(event)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::text_map_propagator;
+    use opentelemetry::propagation::TextMapPropagator as _;
+
+    #[test]
+    fn text_map_propagator_includes_baggage_when_enabled() {
+        let propagator = text_map_propagator(true);
+        let fields = propagator.fields().collect::<Vec<_>>();
+
+        assert!(fields.contains(&"traceparent"));
+        assert!(fields.contains(&"baggage"));
+    }
+
+    #[test]
+    fn text_map_propagator_omits_baggage_when_disabled() {
+        let propagator = text_map_propagator(false);
+        let fields = propagator.fields().collect::<Vec<_>>();
+
+        assert!(fields.contains(&"traceparent"));
+        assert!(!fields.contains(&"baggage"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,15 @@
 #[cfg(feature = "amqp")]
 pub mod amqp;
 
+#[cfg(feature = "init")]
+mod baggage_span_processor;
+#[cfg(feature = "init")]
+pub use baggage_span_processor::BaggageSpanProcessor;
+
 #[cfg(feature = "grpc")]
 pub mod grpc;
 
 #[cfg(feature = "init")]
 mod init;
 #[cfg(feature = "init")]
-pub use init::{init, Handle};
+pub use init::{init, init_with_baggage, Handle};


### PR DESCRIPTION
## Summary
- add a `BaggageSpanProcessor` that copies allowlisted baggage keys to spans during `on_start`
- expose `init_with_baggage(...)` so callers can opt into baggage-backed span attributes without changing the default `init(...)` behavior
- enable baggage propagation only when baggage support is requested, while still covering trace context and adding tests for the propagator wiring

## Testing
- cargo check --all-features
- cargo test --all-features
- rtk proxy cargo clippy --all-features -- -D warnings
