### PR TITLE
feat: forward log source location to OTLP logs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ env_logger = { version = "0.11.5", features = ["auto-color", "humantime", "unsta
 fe2o3-amqp-types = { version = "0.14.0", features = ["primitive", "messaging"], default-features = false, optional = true }
 http = { version = "1.1.0", default-features = false, optional = true }
 log = { version = "0.4.22", features = ["kv_std"], default-features = false, optional = true }
-opentelemetry-appender-log = { version = "0.32.0", default-features = false, optional = true }
+opentelemetry-appender-log = { version = "0.32.0", default-features = false, features = ["experimental_metadata_attributes"], optional = true }
 opentelemetry-otlp = { version = "0.32.0", features = ["grpc-tonic", "gzip-tonic", "logs", "metrics", "trace"], default-features = false, optional = true }
 opentelemetry-semantic-conventions = { version = "0.32.0", features = ["semconv_experimental"], default-features = false, optional = true }
 opentelemetry_sdk = { version = "0.32.0", features = ["rt-tokio", "trace"], default-features = false, optional = true }


### PR DESCRIPTION
## Summary

Enable the `experimental_metadata_attributes` feature on `opentelemetry-appender-log` so every log record carries its source location as OTLP attributes: `code.file.path`, `code.line.number`, and `code.function.name` (module path).

These come straight from `log::Record::{file,line,module_path}` (captured at each `log::*!` call site) and were previously dropped — the appender only emits them under this feature gate, and we pulled it with `default-features = false`.

The feature's only extra dependency is `opentelemetry-semantic-conventions`, which trail already depends on, so this adds no new crates.

## Why

Downstream wants a per-call-site error signature in Loki to detect brand-new error signatures — the self-hosted replacement for Sentry's new-issue Slack alerts. The call site is a stable fingerprint (log message text is not), and this is the central, zero-per-call-site way to surface it.

## Notes

- Applies to all log levels, not just errors. In Loki 3.x, OTLP log attributes land as structured metadata (not stream labels), so there is no label-cardinality impact — only a small per-record volume increase.
